### PR TITLE
Improve associate algorithm between actual and described

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -30,10 +30,6 @@ func AssociateRules(cweRules []*cloudwatchevents.Rule, describedRules []Rule) []
 
 func AssociateTargets(cweTargets []*cloudwatchevents.Target, describedTargets []Target) []Target {
 	// if ClowdWatchEvents Targets is more than declareted targets, append number of lack target{}
-	if l := len(cweTargets) - len(describedTargets); l > 0 {
-		t := make([]Target, l)
-		describedTargets = append(describedTargets, t...)
-	}
 	dupCWETargets := make([]*cloudwatchevents.Target, len(cweTargets))
 	copy(dupCWETargets, cweTargets)
 
@@ -48,14 +44,11 @@ func AssociateTargets(cweTargets []*cloudwatchevents.Target, describedTargets []
 	}
 	if len(dupCWETargets) > 0 {
 		for _, dupTarget := range dupCWETargets {
-			for j, target := range describedTargets {
-				if target.ActualTarget.Arn == nil {
-					describedTargets[j].ActualTarget = *dupTarget
-				}
-			}
+			describedTargets = append(describedTargets, Target{
+				ActualTarget: *dupTarget,
+			})
 		}
 	}
-
 	return describedTargets
 }
 

--- a/builder.go
+++ b/builder.go
@@ -6,10 +6,6 @@ import (
 
 // Associate ClowdWatchEvent Rule and descripbed Rule(name based)
 func AssociateRules(cweRules []*cloudwatchevents.Rule, describedRules []Rule) []Rule {
-	if l := len(cweRules) - len(describedRules); l > 0 {
-		r := make([]Rule, l)
-		describedRules = append(describedRules, r...)
-	}
 	dupCWERules := make([]*cloudwatchevents.Rule, len(cweRules))
 	copy(dupCWERules, cweRules)
 
@@ -24,11 +20,9 @@ func AssociateRules(cweRules []*cloudwatchevents.Rule, describedRules []Rule) []
 	}
 	if len(dupCWERules) > 0 {
 		for _, dupRule := range dupCWERules {
-			for j, rule := range describedRules {
-				if rule.ActualRule.Arn == nil {
-					describedRules[j].ActualRule = *dupRule
-				}
-			}
+			describedRules = append(describedRules, Rule{
+				ActualRule: *dupRule,
+			})
 		}
 	}
 	return describedRules

--- a/builder_test.go
+++ b/builder_test.go
@@ -73,18 +73,6 @@ func TestAssociateRules(t *testing.T) {
 		}
 	}
 
-	cweRules2 := []*cloudwatchevents.Rule{
-		&cloudwatchevents.Rule{
-			Arn:                aws.String("arn:aws:events:ap-northeast-1:000000000000:rule/test-1"),
-			Description:        aws.String("Test rule 1"),
-			EventPattern:       nil,
-			Name:               aws.String("test-1"),
-			RoleArn:            nil,
-			ScheduleExpression: aws.String("cron(0 20 * * ? *)"),
-			State:              aws.String("ENABLED"),
-		},
-	}
-
 	describedRules3 := []Rule{
 		Rule{
 			Description:        "Test rule 2",
@@ -93,17 +81,27 @@ func TestAssociateRules(t *testing.T) {
 			ScheduleExpression: "cron(0 20 2 * ? *)",
 			State:              "ENABLED",
 		},
+		Rule{
+			Description:        "Test rule 3",
+			EventPattern:       "",
+			Name:               "test-3",
+			ScheduleExpression: "cron(0 10 * * ? *)",
+			State:              "ENABLED",
+		},
 	}
-	result3 := AssociateRules(cweRules2, describedRules3)
-	if l := len(result3); l != 2 {
-		t.Errorf("result3 length should 2 but length is %d", l)
+	result3 := AssociateRules(cweRules, describedRules3)
+	if l := len(result3); l != 3 {
+		t.Errorf("result3 length should 3 but length is %d", l)
 	}
 	for i, r := range result3 {
-		if r.Name == "test-2" && r.ActualRule.Name != nil {
-			t.Errorf("result3[%d] should associate empty but associated %s", i, *r.ActualRule.Name)
-		}
 		if r.Name == "" && *r.ActualRule.Name != "test-1" {
 			t.Errorf("result3[%d] (empty) should associate 'test-1' but associated %s", i, *r.ActualRule.Name)
+		}
+		if r.Name == "test-2" && *r.ActualRule.Name != "test-2" {
+			t.Errorf("result3[%d] should associate 'test-2' but associated %s", i, *r.ActualRule.Name)
+		}
+		if r.Name == "test-3" && r.ActualRule.Name != nil {
+			t.Errorf("result3[%d] should associate empty but associated %s", i, *r.ActualRule.Name)
 		}
 	}
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -160,6 +160,32 @@ func TestAssociateTargets(t *testing.T) {
 			t.Errorf("result2[%d] (empty) should associate 'Id1' but associated %s", i, *r.ActualTarget.Id)
 		}
 	}
+
+	testTargets3 := []Target{
+		Target{
+			Arn: "arn:aws:lambda:ap-northeast-1:000000000000:function:test-2",
+			Id:  "Id2",
+		},
+		Target{
+			Arn: "arn:aws:lambda:ap-northeast-1:000000000000:function:test-3",
+			Id:  "Id3",
+		},
+	}
+	result3 := AssociateTargets(cweTargets, testTargets3)
+	if l := len(result3); l != 3 {
+		t.Errorf("testTargets3 length should be 3 but length is %d", l)
+	}
+	for i, r := range result3 {
+		if r.Id == "" && *r.ActualTarget.Id != "Id1" {
+			t.Errorf("ActualTarget 'Id1' should associate empty target but associated %s", r.Id)
+		}
+		if r.Id == "Id2" && r.Arn != *r.ActualTarget.Arn {
+			t.Errorf("result3[%d] should associate 'Id2' but associated %s", i, *r.ActualTarget.Id)
+		}
+		if r.Id == "Id3" && r.ActualTarget.Id != nil {
+			t.Errorf("result3[%d] (empty) should associate empty ActualTarget but associated %s", i, *r.ActualTarget.Id)
+		}
+	}
 }
 
 func TestJudgeRuleNeedUpdate(t *testing.T) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -72,6 +72,40 @@ func TestAssociateRules(t *testing.T) {
 			t.Errorf("result2[%d] (empty) should associate 'test-1' but associated %s", i, *r.ActualRule.Name)
 		}
 	}
+
+	cweRules2 := []*cloudwatchevents.Rule{
+		&cloudwatchevents.Rule{
+			Arn:                aws.String("arn:aws:events:ap-northeast-1:000000000000:rule/test-1"),
+			Description:        aws.String("Test rule 1"),
+			EventPattern:       nil,
+			Name:               aws.String("test-1"),
+			RoleArn:            nil,
+			ScheduleExpression: aws.String("cron(0 20 * * ? *)"),
+			State:              aws.String("ENABLED"),
+		},
+	}
+
+	describedRules3 := []Rule{
+		Rule{
+			Description:        "Test rule 2",
+			EventPattern:       "",
+			Name:               "test-2",
+			ScheduleExpression: "cron(0 20 2 * ? *)",
+			State:              "ENABLED",
+		},
+	}
+	result3 := AssociateRules(cweRules2, describedRules3)
+	if l := len(result3); l != 2 {
+		t.Errorf("result3 length should 2 but length is %d", l)
+	}
+	for i, r := range result3 {
+		if r.Name == "test-2" && r.ActualRule.Name != nil {
+			t.Errorf("result3[%d] should associate empty but associated %s", i, *r.ActualRule.Name)
+		}
+		if r.Name == "" && *r.ActualRule.Name != "test-1" {
+			t.Errorf("result3[%d] (empty) should associate 'test-1' but associated %s", i, *r.ActualRule.Name)
+		}
+	}
 }
 
 func TestAssociateTargets(t *testing.T) {


### PR DESCRIPTION
## before
- If actual rule(target) is surplus, associate non-appropriate described rule(target)

## after
- Append actual rule(target) to associate empty rule(target)
    - The actual rule(target) will be delete.